### PR TITLE
Release v2.34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .*.swp
 tmp/
 log/
+.vagrant/
 
 # Config
 etc/config.xml

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,48 @@ Seccubus V2 works with the following scanners:
 
 For more information visit [www.seccubus.com]
 
+15-6-2017 - v2.34 - Backemnd rewritten in Mojolicious
+=====================================================
+
+The Seccubusd backend has been REST-ish ever since release v2.0. This web backend was implemented
+via Perl CGI scripts (yes, using CGI.pm). Needless to say something needed to change.
+
+This backend rewrite has been in the making for some time now and we are finally ready to release
+it into the wild.
+
+What are the major changes?
+* Backend rewritten in [Mojolicious](http://mojolicious.org/)
+* Backend API is now REST compliant and located at /api
+* There is no need to run an external webserver for Seccubus, it is built into Mojolicious
+* Seccubus now has built in user authentication (Defaqult admin password is 'GiveMeVulns!')
+* Fixed a lot off old issues
+* Unfortunately there is no solid Mojolicious v6/v7 rpms for RedHat/Centos, so we can no longer provide RPMs for those operating systems
+
+Enhancements
+------------
+* #411 - Ported the backend to Mojolicious and pure REST
+* #448 - Allow import and export utility to read config from specific file
+
+Bug Fixes
+---------
+* Fixed a weird sorting bug when using Chrome
+* #138 - Can't locate SeccubusV2.pm in @INC (you may need to install the SeccubusV2 module)
+* #143 - Make RPM so that nginx is supported too
+* #171 - column formatting in custom SQL is off
+* #190 - XSS in custom SQL query
+* #193 - RFE: please add a logout button for additional security
+* #263 - SeccubusHelpers.pm contains two unused functions
+* #363 - API calls for asset use workspace iso of workspaceId which is the standard
+* #384 - Missing SMTP server config should be warning, not error
+* #396 - ConfigTest should return non 200 if config is not ok
+* #417 - Docker container is not https-enabled by default
+* #418 - Docker images lacks proper data management
+* #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
+* #445 - RPM errors
+* #457 - Mine attachment not sent correctly
+* #465 - JSON::false returns "false" on certain platforms
+* #466 - /api/version should not be an authenticated call
+
 18-4-2017 - v2.32 - Added dist tag to RPM filename
 ==================================================
 
@@ -73,10 +115,10 @@ Bug Fixes
 20-2-2017 - v2.28 - The Docker edition
 ======================================
 
-For my work at [Schuberg Philis](https://www.schubergphilis.com) we wanted to run Seccubus in Docker 
-containers. This and inspiration from [Karl Newell](https://hub.docker.com/r/karlnewell/seccubus/) 
-caused me to add a Dockerfile (and some other files) to Seccubus so that Seccubus can now be 
-run in a docker container. 
+For my work at [Schuberg Philis](https://www.schubergphilis.com) we wanted to run Seccubus in Docker
+containers. This and inspiration from [Karl Newell](https://hub.docker.com/r/karlnewell/seccubus/)
+caused me to add a Dockerfile (and some other files) to Seccubus so that Seccubus can now be
+run in a docker container.
 
 In addition I fixed a couple of bugs and changed the ssllabs scanner so it now uses the v3 API endpoint.
 
@@ -84,7 +126,7 @@ In addition I fixed a couple of bugs and changed the ssllabs scanner so it now u
 - #361 - arkenoi created a netsparker2ivil tool that allows you to manually import Netsparker scans
 - #331 - Now using SSLLabs API v3
 - #386 - New SSL labs API output featues incorporporated
-- #389 - API endpoint URL has moved to a single function so it can be patched if deployed in a 
+- #389 - API endpoint URL has moved to a single function so it can be patched if deployed in a
        three tier architecture
 - #392 - Alternative handling of the updateFIndings.pl API
 - #397 - Allow seccubus to authenticate via an http request header
@@ -101,26 +143,26 @@ In addition I fixed a couple of bugs and changed the ssllabs scanner so it now u
 - #385 - SSLlabs failed because cypher preference order was split out per protocol by SSLlabs now.
 - #394 - SSLlabs scanner failed if all enpoints fail and --gradeonly was used
 
-Docker image at https://hub.docker.com/r/seccubus/seccubus/ 
+Docker image at https://hub.docker.com/r/seccubus/seccubus/
 
 12-7-2016 - 2.26 - Speed improvements and a whole log of bugfixes
 =================================================================
 This release is especially interesting for those of you that are working with large result sets.
 The number of findigns that is returned is now limited to 200 results by default and can be adjusted
 up or down.
-A lot of the filter logic has been moved from the Perl backend to more intelligent database queries 
+A lot of the filter logic has been moved from the Perl backend to more intelligent database queries
 where caching and other optimalisations techniques prevent timeouts when working with larger result
 sets.
 
 Additional improvements are done the rpm packaging and the Nessus6 scanner wich now no longer depends
 on certain excotic perl modules.
 
-The number of change records that is created and displayed has been reduced and some other more minor 
+The number of change records that is created and displayed has been reduced and some other more minor
 have been fixed too.
 
 Enhancements
 ------------
-* #128 - Limit the amount of findings that is returned from the back end 
+* #128 - Limit the amount of findings that is returned from the back end
 * #312 - SSLLabs and Nessus6 scanner no longer depend on perl-REST-Client
 * #319 - RPM now builds and installs under CentOs/RHEL 5 too
 * #320 - Nessus6 scanner now downloads PDF and HTML version of report too
@@ -157,7 +199,7 @@ Bug Fixes
 * #311 - RPM: Config could not be found after version upgrade to 2.22
 * #313 - RPM: Seccubus.conf not placed in correct directory (v2.22)
 * #314 - RPM: v2.22 /opt/seccubus/www/dev should not exist
-* #315 - RPM: v2.22 dependancy mysql-server is not installed 
+* #315 - RPM: v2.22 dependancy mysql-server is not installed
 
 08-04-2016 - 2.22 - OpenVAS intergration fixed
 ==============================================
@@ -176,7 +218,7 @@ Bug Fixes
 ---------
 * #289 - Online version test needs a unit test
 * #269 - Correct handling of multiple address nodes in NMap XML
-* #298 - OpenVAS6: fix scan and import to ivil 
+* #298 - OpenVAS6: fix scan and import to ivil
 * #297 - Port field abused to store port state
 * #307 - OpenVAS integration was broken
 
@@ -249,7 +291,7 @@ Bug Fixes
 * #236 - Database upgrades inconsistent
 * #243 - do-scan -q is not very quiet
 * #247 - SSLLabs: certain values for PoodleTLS not handled
-* #248 - SSLLabs Reneg finding empty is reneg is not supported 
+* #248 - SSLLabs Reneg finding empty is reneg is not supported
 * Copyright related unit tests now work on Travis CI too
 * #252 - scannerparam column in scans table too small
 * #255 - Incorrect use of CGI.pm may cause parameter injection vulnerability
@@ -260,7 +302,7 @@ Using the quiet(er) time after summer to get some bug fixes in.
 
 Enhancements
 ------------
-* #211 - Host filter now splits on / as well as . 
+* #211 - Host filter now splits on / as well as .
 
 Bug Fixes
 ---------
@@ -291,7 +333,7 @@ Seccubus OWASP ZAP Proxy release
 
 The OWASP Zed Attack Proxy (ZAP) is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.
 
-It is designed to be used by people with a wide range of security experience and as such is ideal for developers and functional testers who are new to penetration testing as well as being a useful addition to an experienced pen testers toolbox. 
+It is designed to be used by people with a wide range of security experience and as such is ideal for developers and functional testers who are new to penetration testing as well as being a useful addition to an experienced pen testers toolbox.
 
 The intergration with Seccubus will make you able to launch the ZAP proxy scanner from the commandline and proccess the results into Seccubus. The default policy will be applicable when the scanner is launched. This can be altered by running the program "normally" with ./zap.sh and adjust the policy in the ZAP Gui
 
@@ -355,7 +397,7 @@ Bug Fixes
 01-08-2014 - 2.8 - New scanner and Burp parser
 ============================================
 Medusa is added to scanner tools thnx to @Arkanoi
-Added burp parser to ivil thnx to @SphaZ 
+Added burp parser to ivil thnx to @SphaZ
 
 Bug Fixes
 ============================================
@@ -498,7 +540,7 @@ New features / Issues resolved
 * Build is now automated using a Jenkins server at Schuberg Philis including
   the creation of RPMs and Debian packages via OpenSuse build services
 * Fixed a few bugs
-    
+
 Bigs fixed (tickets closed):
 ----------------------------
 * #7  - Import error on scan results from OpenVAS 3.0.1
@@ -512,8 +554,8 @@ Bigs fixed (tickets closed):
 * #23 - Nessus xmlRPC port can now be selected
 * #25 - Fixed tarball installation error
 * #29 - JMVC framework updated to version 3.2.2
-    
-15-8-2012 - 2.0.beta5 
+
+15-8-2012 - 2.0.beta5
 =====================
 This is basically version 2.0.beta4 with a nasty critical error removed.
 
@@ -525,7 +567,7 @@ Bigs fixed (tickets closed):
 ----------------------------
 91 - Scan_ids is a mandatory parameter
 
-10-6-2012 - 2.0.beta4 
+10-6-2012 - 2.0.beta4
 =====================
 
 New features / Issues resolved
@@ -623,7 +665,7 @@ Bigs fixed (tickets closed):
 ----------------------------
 49 - Incorrect status selection possible in GUI for Gone findings
 https://sourceforge.net/apps/trac/seccubus/ticket/49
-58 - Cannot give GONE findings the status CLOSED 
+58 - Cannot give GONE findings the status CLOSED
 https://sourceforge.net/apps/trac/seccubus/ticket/58
 
 
@@ -688,11 +730,11 @@ https://sourceforge.net/apps/trac/seccubus/ticket/12
 #42 - Scan parameters --workspace and --scan should be added automatically
 https://sourceforge.net/apps/trac/seccubus/ticket/42
 
-17-03-2011 - 2.0.alpha2 
+17-03-2011 - 2.0.alpha2
 =======================
 New features / Issues resolved
 ------------------------------
-Fixed slow speed of updates to multiple findings  
+Fixed slow speed of updates to multiple findings
 Scanning with Nessus should work a lot better in this version
 
 Bug fixed:

--- a/README.md
+++ b/README.md
@@ -142,11 +142,22 @@ Changes of this branch vs the [latest/previous release](https://github.com/schub
 
 ---
 
-x-x-2017 - v2.33 - Development release
-==================================================
+15-6-2017 - v2.34 - Backemnd rewritten in Mojolicious
+=====================================================
 
-This release is a fixup release of version 2.30. It fixes two errors in import/export and provides
-specific RPMs for el5, el6 and el7 now.
+The Seccubusd backend has been REST-ish ever since release v2.0. This web backend was implemented
+via Perl CGI scripts (yes, using CGI.pm). Needless to say something needed to change.
+
+This backend rewrite has been in the making for some time now and we are finally ready to release
+it into the wild.
+
+What are the major changes?
+* Backend rewritten in [Mojolicious](http://mojolicious.org/)
+* Backend API is now REST compliant and located at /api
+* There is no need to run an external webserver for Seccubus, it is built into Mojolicious
+* Seccubus now has built in user authentication (Defaqult admin password is 'GiveMeVulns!')
+* Fixed a lot off old issues
+* Unfortunately there is no solid Mojolicious v6/v7 rpms for RedHat/Centos, so we can no longer provide RPMs for those operating systems
 
 Enhancements
 ------------

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Bug Fixes
 * #417 - Docker container is not https-enabled by default
 * #418 - Docker images lacks proper data management
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
+* #445 - RPM errors
 * #457 - Mine attachment not sent correctly
 * #465 - JSON::false returns "false" on certain platforms
 * #466 - /api/version should not be an authenticated call

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ Enhancements
 
 Bug Fixes
 ---------
-* #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * Fixed a weird sorting bug when using Chrome
+* #418 - Docker images lacks proper data management
+* #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * #457 - Mine attachment not sent correctly
 * #465 - JSON::false returns "false" on certain platforms
 * #466 - /api/version should not be an authenticated call

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #143 - Make RPM so that nginx is supported too
 * #171 - column formatting in custom SQL is off
 * #190 - XSS in custom SQL query
 * #193 - RFE: please add a logout button for additional security

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #363 - API calls for asset use workspace iso of workspaceId which is the standard
 * #384 - Missing SMTP server config should be warning, not error
 * #396 - ConfigTest should return non 200 if config is not ok
 * #417 - Docker container is not https-enabled by default

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #171 - column formatting in custom SQL is off
 * #190 - XSS in custom SQL query
 * #193 - RFE: please add a logout button for additional security
 * #263 - SeccubusHelpers.pm contains two unused functions

--- a/README.md
+++ b/README.md
@@ -150,10 +150,11 @@ specific RPMs for el5, el6 and el7 now.
 
 Enhancements
 ------------
-*
+* #411 - Ported the backend to Mojolicious and pure REST
 * #448 - Allow import and export utility to read config from specific file
 
 Bug Fixes
 ---------
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * Fixed a weird sorting bug when using Chrome
+* #465 - JSON::false returns "false" on certain platforms

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #396 - ConfigTest should return non 200 if config is not ok
 * #417 - Docker container is not https-enabled by default
 * #418 - Docker images lacks proper data management
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #190 - XSS in custom SQL query
 * #193 - RFE: please add a logout button for additional security
 * #263 - SeccubusHelpers.pm contains two unused functions
 * #363 - API calls for asset use workspace iso of workspaceId which is the standard

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #138 - Can't locate SeccubusV2.pm in @INC (you may need to install the SeccubusV2 module)
 * #143 - Make RPM so that nginx is supported too
 * #171 - column formatting in custom SQL is off
 * #190 - XSS in custom SQL query

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #384 - Missing SMTP server config should be warning, not error
 * #396 - ConfigTest should return non 200 if config is not ok
 * #417 - Docker container is not https-enabled by default
 * #418 - Docker images lacks proper data management

--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ Bug Fixes
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * Fixed a weird sorting bug when using Chrome
 * #465 - JSON::false returns "false" on certain platforms
+* #466 - /api/version should not be an authenticated call

--- a/README.md
+++ b/README.md
@@ -157,5 +157,6 @@ Bug Fixes
 ---------
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * Fixed a weird sorting bug when using Chrome
+* #457 - Mine attachment not sent correctly
 * #465 - JSON::false returns "false" on certain platforms
 * #466 - /api/version should not be an authenticated call

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #193 - RFE: please add a logout button for additional security
+* #263 - SeccubusHelpers.pm contains two unused functions
 * #363 - API calls for asset use workspace iso of workspaceId which is the standard
 * #384 - Missing SMTP server config should be warning, not error
 * #396 - ConfigTest should return non 200 if config is not ok

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Enhancements
 Bug Fixes
 ---------
 * Fixed a weird sorting bug when using Chrome
+* #417 - Docker container is not https-enabled by default
 * #418 - Docker images lacks proper data management
 * #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
 * #457 - Mine attachment not sent correctly

--- a/SeccubusV2.pm
+++ b/SeccubusV2.pm
@@ -50,7 +50,7 @@ use lib "/opt/seccubus/lib";
 use lib "lib";
 push (@main::INC, @INC);
 
-$VERSION = '2.33';
+$VERSION = '2.34';
 $DBVERSION = 10;
 $USER = '';
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,108 @@
+# ------------------------------------------------------------------------------
+# Copyright 2017 Frank Breedijk, Glen Hinkle
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "bento/fedora-25"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  #config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+
+  config.vm.define "f24" do |f|
+    f.vm.network "forwarded_port", guest: 8443, host: 824, host_ip: "127.0.0.1"
+    f.vm.box = "bento/fedora-24"
+  end
+
+  config.vm.define "f25" do |f|
+    f.vm.network "forwarded_port", guest: 8443, host: 825, host_ip: "127.0.0.1"
+    f.vm.box = "bento/fedora-25"
+  end
+
+  #config.vm.define "f26" do |f|
+  #  f.vm.network "forwarded_port", guest: 8443, host: 826, host_ip: "127.0.0.1"
+  #  f.vm.box = "bento/fedora-26"
+  #end
+
+end

--- a/deb/debian.postrm
+++ b/deb/debian.postrm
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2013 Frank Breedijk
+# Copyright 2012-2017 Frank Breedijk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/Seccubus.pm
+++ b/lib/Seccubus.pm
@@ -192,7 +192,7 @@ sub startup {
     $auth_api->get   ('api/workspace/:workspace_id/scan/:scan_id/runs')->to('runs#list');
 
     # Version
-    $auth_api->get   ('api/version')->to('version#read');
+    $r->get          ('api/version')->to('version#read');
 
     # Workspace
     $auth_api->post  ('api/workspaces')->to('workspaces#create');

--- a/lib/Seccubus/Controller/Sessions.pm
+++ b/lib/Seccubus/Controller/Sessions.pm
@@ -22,7 +22,6 @@ use SeccubusV2;
 use Seccubus::Users;
 use Seccubus::DB;
 use Data::Dumper;
-use JSON;
 
 # Create
 sub create {
@@ -70,11 +69,6 @@ sub create {
     );
     $self->session->{user}->{hash} = $hash;
     my ( $username, $valid, $isadmin, $message ) = get_login($user->{username});
-    if ( $isadmin ) {
-        $isadmin = JSON::true;
-    } else {
-        $isadmin = JSON::false;
-    }
 
     $self->render( json => {
         status  => "Success",
@@ -109,11 +103,6 @@ sub read {
 
         ($data->{username}, $data->{valid}, $data->{isAdmin}, $data->{message}) = get_login();
 
-        #if ( $data->{isAdmin} ) {
-        #    $data->{isAdmin} = JSON::true;
-        #} else {
-        #    $data->{isAdmin} = JSON::false;
-        #}
         $data->{username} = "" unless $data->{username};
 
         $self->render( json => $data );

--- a/lib/Seccubus/Findings.pm
+++ b/lib/Seccubus/Findings.pm
@@ -27,7 +27,6 @@ use Seccubus::Rights;
 use Seccubus::Users;
 use Seccubus::Issues;
 use Algorithm::Diff qw( diff );
-use JSON;
 use Data::Dumper;
 
 @ISA = ('Exporter');
@@ -473,17 +472,17 @@ sub get_filters($$$;$) {
                 $host->{number} = $count{$host->{name}};
             }
             if ( $host->{name} eq $filter->{host} ) {
-                $host->{selected} = JSON::true;
+                $host->{selected} = 1;
             } else {
-                $host->{selected} = JSON::false;
+                $host->{selected} = 0;
             }
         }
-        push @hosts, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @hosts, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $host ( @$hosts_out ) {
             if ( $$host[0] eq $filter->{host} ) {
-                push @hosts, { name => $$host[0], number => $$host[1], selected => JSON::true };
+                push @hosts, { name => $$host[0], number => $$host[1], selected => 1 };
             } else {
-                push @hosts, { name => $$host[0], number => $$host[1], selected => JSON::false };
+                push @hosts, { name => $$host[0], number => $$host[1], selected => 0 };
             }
         }
         $hosts_out = undef;
@@ -529,9 +528,9 @@ sub get_filters($$$;$) {
         foreach my $host ( @$hostnames_in ) {
             $count+=$$host[1];
             if ( $$host[0] eq $filter->{hostname} ) {
-                push @hostnames, { name => $$host[0], number => $$host[1], selected => JSON::true };
+                push @hostnames, { name => $$host[0], number => $$host[1], selected => 1 };
             } else {
-                push @hostnames, { name => $$host[0], number => $$host[1], selected => JSON::false };
+                push @hostnames, { name => $$host[0], number => $$host[1], selected => 0 };
             }
             if ( $hostnames[-1]->{name} eq "" ) {
                 $hostnames[-1]->{name} = "(blank)";
@@ -539,13 +538,13 @@ sub get_filters($$$;$) {
             }
         }
         $hostnames_in = undef;
-        push @hostnames, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @hostnames, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $host ( @$hostnames_out ) {
             $$host[0] = "" unless defined $$host[0];
             if ( $$host[0] eq $filter->{hostname} ) {
-                push @hostnames, { name => $$host[0], number => $$host[1], selected => JSON::true };
+                push @hostnames, { name => $$host[0], number => $$host[1], selected => 1 };
             } else {
-                push @hostnames, { name => $$host[0], number => $$host[1], selected => JSON::false };
+                push @hostnames, { name => $$host[0], number => $$host[1], selected => 0 };
             }
         }
         $hostnames_out = undef;
@@ -588,19 +587,19 @@ sub get_filters($$$;$) {
             $count+=$$port[1];
             $$port[0] = "" unless defined $$port[0];
             if ( $$port[0] eq $filter->{port} ) {
-                push @ports, { name => $$port[0], number => $$port[1], selected => JSON::true };
+                push @ports, { name => $$port[0], number => $$port[1], selected => 1 };
             } else {
-                push @ports, { name => $$port[0], number => $$port[1], selected => JSON::false };
+                push @ports, { name => $$port[0], number => $$port[1], selected => 0 };
             }
         }
         $ports_in = undef;
-        push @ports, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @ports, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $port ( @$ports_out ) {
             $$port[0] = "" unless defined $$port[0];
             if ( $$port[0] eq $filter->{port} ) {
-                push @ports, { name => $$port[0], number => $$port[1], selected => JSON::true };
+                push @ports, { name => $$port[0], number => $$port[1], selected => 1 };
             } else {
-                push @ports, { name => $$port[0], number => $$port[1], selected => JSON::false };
+                push @ports, { name => $$port[0], number => $$port[1], selected => 0 };
             }
         }
         $ports_out = undef;
@@ -647,20 +646,20 @@ sub get_filters($$$;$) {
             $count+=$$plugin[1];
             $$plugin[0] = "" unless defined $$plugin[0];
             if ( $$plugin[0] eq $filter->{plugin} ) {
-                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => JSON::true };
+                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => 1 };
             } else {
-                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => JSON::false };
+                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => 0 };
             }
         }
 
         $plugins_in = undef;
-        push @plugins, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @plugins, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $plugin ( @$plugins_out ) {
             $$plugin[0] = "" unless defined $$plugin[0];
             if ( $$plugin[0] eq $filter->{plugin} ) {
-                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => JSON::true };
+                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => 1 };
             } else {
-                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => JSON::false };
+                push @plugins, { name => $$plugin[0], number => $$plugin[1], selected => 0 };
             }
         }
         $plugins_out = undef;
@@ -705,18 +704,18 @@ sub get_filters($$$;$) {
         foreach my $severity ( @$severitys_in ) {
             $count+=$$severity[2];
             if ( $$severity[0] eq $filter->{severity} ) {
-                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => JSON::true };
+                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => 1 };
             } else {
-                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => JSON::false };
+                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => 0 };
             }
         }
         $severitys_in = undef;
-        push @severitys, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @severitys, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $severity ( @$severitys_out ) {
             if ( $$severity[0] eq $filter->{severity} ) {
-                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => JSON::true };
+                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => 1 };
             } else {
-                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => JSON::false };
+                push @severitys, { value => $$severity[0], name=>$$severity[1], number => $$severity[2], selected => 0 };
             }
         }
         $severitys_out = undef;
@@ -768,21 +767,21 @@ sub get_filters($$$;$) {
                 $issue_name = "$$issue[1] ($$issue[2])";
                 $issue_value = $$issue[0];
                 if ( $$issue[0] eq $filter->{issue} ) {
-                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => JSON::true };
+                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => 1 };
                 } else {
-                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => JSON::false };
+                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => 0 };
                 }
             }
         }
         $issues_in = undef;
-        push @issues, { "name" => "---", "number" => -1, selected => JSON::false };
+        push @issues, { "name" => "---", "number" => -1, selected => 0 };
         foreach my $issue ( @$issues_out ) {
             my $issue_name = "$$issue[1] ($$issue[2])";
             if ( defined $$issue[1] ) {
                 if ( $$issue[0] eq $filter->{issue} ) {
-                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => JSON::true };
+                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => 1 };
                 } else {
-                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => JSON::false };
+                    push @issues, { value => $$issue[0], name=>$issue_name, number => $$issue[3], selected => 0 };
                 }
             }
         }

--- a/lib/Seccubus/Helpers.pm
+++ b/lib/Seccubus/Helpers.pm
@@ -42,8 +42,6 @@ use Data::Dumper;
 
 sub check_config();
 sub dirlist($;$);
-sub api_error($$);
-sub api_result($;$$$);
 sub run_cmd($;$$$$);
 
 
@@ -96,104 +94,6 @@ sub dirlist($;$) {
     return @FILES_TMP;
 }
 
-=head2 api_error
-
-This function prints a standard Seccubus API error message and exits the program
-
-=over 2
-
-=item Parameters
-
-=over 4
-
-=item api_name - Name of the api that returns the error
-
-=item message  - Error message in the error output
-
-=back
-
-=item Returns
-
-None
-
-=item Checks
-
-None
-
-=back
-
-=back
-
-=cut
-
-sub api_error($$) {
-	my $api_name = shift;
-	my $error_msg = shift;
-
-	print "<seccubusAPI name='$api_name'>\n";
-	print "<result>NOK</result>\n";
-	print "<message>" . encode_entities($error_msg) . "</message>\n";
-	print "</seccubusAPI>\n";
-	exit;
-}
-
-=head2 api_result
-
-This function prints a standard Seccubus API output message.
-
-=over 2
-
-=item Parameters
-
-=over 4
-
-=item api_name - Name of the api that returns the output
-
-=item message  - Optional message in the output
-
-=item data     - Optional data segment in the output
-
-=item iserror  - Optional, indicates that the output is an error message, negative by default
-
-=back
-
-=item Returns
-
-None
-
-=item Checks
-
-None
-
-=back
-
-=back
-
-=cut
-
-sub api_result($;$$$) {
-	my $api_name = shift;
-	my $msg = shift;
-	my $data = shift;
-	my $iserror = shift;
-
-	if ( $iserror ) {
-		$iserror = "OK";
-	} else {
-		$iserror = "NOK";
-	}
-
-	print "<seccubusAPI name='$api_name'>\n";
-	print "<result>$iserror</result>\n";
-	if ( $msg ) {
-		print "<message>" . encode_entities($msg) . "</message>\n";
-	}
-	if ( $data ) {
-		print "<data>\n$data\n</data>";
-	}
-	print "</seccubusAPI>\n";
-	exit;
-}
 
 =head2 run_cmd
 

--- a/lib/Seccubus/Notifications.pm
+++ b/lib/Seccubus/Notifications.pm
@@ -549,9 +549,9 @@ Content-Type: multipart/mixed; boundary=\"seccubus-message-part\"
 This is a message with multiple parts in MIME format.
 --seccubus-message-part
 Content-Type: text/plain\n\n" . $$notification[2];
-				$$notification[2] .= "--seccubus-message-part\n";
-				$$notification[2] .= join "--seccubus-message-part\n", @attachments;
-				$$notification[2] .= "--seccubus-message-part\n";
+				$$notification[2] .= "\n\n--seccubus-message-part\n";
+				$$notification[2] .= join "\n\n--seccubus-message-part\n", @attachments;
+				$$notification[2] .= "\n\n--seccubus-message-part\n";
 			} else {
 				$$notification[2] = "\n$$notification[2]";
 			}

--- a/t/51_version.t
+++ b/t/51_version.t
@@ -31,7 +31,7 @@ $t->get_ok('/api/version')
 	->status_is(200)
 	->json_is("/link","")
 	->json_like("/status",qr/^(OK|WARN)$/)
-	->json_like("/message",qr/(active development version|is up to date)/i)
+	->json_like("/message",qr/(using the newest version|active development version|is up to date)/i)
 	;
 
 done_testing();

--- a/t/60_session.t
+++ b/t/60_session.t
@@ -18,7 +18,6 @@ use strict;
 
 use Test::More;
 use Test::Mojo;
-use JSON;
 
 use lib "lib";
 
@@ -52,7 +51,7 @@ $t->get_ok('/api/appstatus')
 $t->get_ok('/api/session')
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::false,
+        isAdmin     => 0,
         message     => "Undefined user 'Not logged in'",
         username    => "",
         valid       => 0
@@ -108,7 +107,7 @@ $t->post_ok('/api/session', json => { username => "admin", password => "GiveMeVu
 $t->get_ok('/api/session')
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::true,
+        isAdmin     => 1,
         message     => "Valid user 'Builtin administrator account' (admin)",
         username    => "admin",
         valid       => 1
@@ -146,7 +145,7 @@ $t->post_ok('/api/session', { 'REMOTEUSER' => 'importer' } => json => {})
 $t->get_ok('/api/session')
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::true,
+        isAdmin     => 1,
         message     => "Valid user 'Builtin importer utility account' (importer)",
         username    => "importer",
         valid       => 1
@@ -177,7 +176,7 @@ $t->get_ok('/api/events')
 $t->get_ok('/api/session')
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::false,
+        isAdmin     => 0,
         message     => "Undefined user 'Not logged in'",
         username    => "",
         valid       => 0
@@ -188,7 +187,7 @@ $t->get_ok('/api/session')
 $t->get_ok('/api/session' => { 'REMOTEUSER' => 'system' })
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::true,
+        isAdmin     => 1,
         message     => "Valid user 'Builtin system user' (system)",
         username    => "system",
         valid       => 1
@@ -217,7 +216,7 @@ $t->get_ok('/api/events')
 $t->get_ok('/api/session')
     ->status_is(200)
     ->json_is({
-        isAdmin     => JSON::false,
+        isAdmin     => 0,
         message     => "Undefined user 'Not logged in'",
         username    => "",
         valid       => 0

--- a/t/61_findings+filter+status+assets.t
+++ b/t/61_findings+filter+status+assets.t
@@ -21,7 +21,6 @@ use lib "lib";
 use Test::More;
 use Test::Mojo;
 use Data::Dumper;
-use JSON;
 
 my $db_version = 0;
 foreach my $data_file (<db/data_v*.mysql>) {
@@ -331,7 +330,7 @@ $t->get_ok('/api/workspace/100/findings?Limit=-1&scanIds[]=54345')
 $t->get_ok('/api/workspace/100/filters?scanIds[]=54345')
     ->status_is(200)
     ->json_is(
-        {"finding"=>"","host"=>[{"name"=>"*","number"=>0,"selected"=>JSON::false},{"name"=>"---","number"=>-1,"selected"=>JSON::false}],"hostname"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>JSON::false}],"issue"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>JSON::false}],"plugin"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>JSON::false}],"port"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>JSON::false}],"remark"=>"","severity"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>JSON::false}]}
+        {"finding"=>"","host"=>[{"name"=>"*","number"=>0,"selected"=>0},{"name"=>"---","number"=>-1,"selected"=>0}],"hostname"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>0}],"issue"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>0}],"plugin"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>0}],"port"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>0}],"remark"=>"","severity"=>[{"name"=>"*","number"=>0},{"name"=>"---","number"=>-1,"selected"=>0}]}
     )
 ;
 
@@ -620,37 +619,37 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "*",
                     "number" => 8,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "127.*",
                     "number" => 8,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "127.0.*",
                     "number" => 8,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "127.0.0.*",
                     "number" => 8,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "127.0.0.1",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "127.0.0.2",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ],
             "hostname" => [
@@ -661,18 +660,18 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "(blank)",
                     "number" => 4,
-                    "selected" => JSON::true,
+                    "selected" => 1,
                     "value" => ""
                 },
                 {
                     "name" => "localhost",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ],
             "issue" => [
@@ -683,7 +682,7 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ],
             "plugin" => [
@@ -694,17 +693,17 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "a",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "b",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ],
             "port" => [
@@ -715,17 +714,17 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "a",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "b",
                     "number" => 4,
-                    "selected" => JSON::false
+                    "selected" => 0
                 },
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ],
             "remark" => "",
@@ -737,19 +736,19 @@ $t->get_ok("/api/workspace/101/filters")
                 {
                     "name" => "High",
                     "number" => 4,
-                    "selected" => JSON::false,
+                    "selected" => 0,
                     "value" => "1"
                 },
                 {
                     "name" => "Medium",
                     "number" => 4,
-                    "selected" => JSON::false,
+                    "selected" => 0,
                     "value" => "2"
                 },
                 {
                     "name" => "---",
                     "number" => -1,
-                    "selected" => JSON::false
+                    "selected" => 0
                 }
             ]
         }


### PR DESCRIPTION
15-6-2017 - v2.34 - Backend rewritten in Mojolicious
=====================================================

The Seccubusd backend has been REST-ish ever since release v2.0. This web backend was implemented
via Perl CGI scripts (yes, using CGI.pm). Needless to say something needed to change.

This backend rewrite has been in the making for some time now and we are finally ready to release
it into the wild.

What are the major changes?
* Backend rewritten in [Mojolicious](http://mojolicious.org/)
* Backend API is now REST compliant and located at /api
* There is no need to run an external webserver for Seccubus, it is built into Mojolicious
* Seccubus now has built in user authentication (Defaqult admin password is 'GiveMeVulns!')
* Fixed a lot off old issues
* Unfortunately there is no solid Mojolicious v6/v7 rpms for RedHat/Centos, so we can no longer provide RPMs for those operating systems

Enhancements
------------
* #411 - Ported the backend to Mojolicious and pure REST
* #448 - Allow import and export utility to read config from specific file

Bug Fixes
---------
* Fixed a weird sorting bug when using Chrome
* #138 - Can't locate SeccubusV2.pm in @INC (you may need to install the SeccubusV2 module)
* #143 - Make RPM so that nginx is supported too
* #171 - column formatting in custom SQL is off
* #190 - XSS in custom SQL query
* #193 - RFE: please add a logout button for additional security
* #263 - SeccubusHelpers.pm contains two unused functions
* #363 - API calls for asset use workspace iso of workspaceId which is the standard
* #384 - Missing SMTP server config should be warning, not error
* #396 - ConfigTest should return non 200 if config is not ok
* #417 - Docker container is not https-enabled by default
* #418 - Docker images lacks proper data management
* #430 - Set correct paths for perl and nikto so that do-scan and nikto can now be run by any user
* #445 - RPM errors
* #457 - Mine attachment not sent correctly
* #465 - JSON::false returns "false" on certain platforms
* #466 - /api/version should not be an authenticated call