### PR TITLE
Install hexadump bin via bsdmainutils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ MAINTAINER fbreedijk@schubergphilis.com
 RUN apt-get update && apt-get upgrade -y && \
     (echo 'mysql-server mysql-server/root_password password dwofMVR8&E^#3owHA0!Y' | debconf-set-selections ) && \
     (echo 'mysql-server mysql-server/root_password_again password dwofMVR8&E^#3owHA0!Y' | debconf-set-selections ) && \
-    apt-get install default-jre-headless mysql-server dnsutils nmap nginx cron rsyslog ssmtp -y
+    apt-get install default-jre-headless mysql-server dnsutils nmap nginx cron rsyslog ssmtp bsdmainutils -y
 RUN cpanm --notest DBD::mysql Mojolicious Net::IP JSON DBI HTML::Entities Crypt::PBKDF2 \
     Algorithm::Diff XML::Simple LWP::Simple LWP::Protocol::https LWP::UserAgent\
     Date::Format Term::ReadKey

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Frank Breedijk
+# Copyright 2017 Frank Breedijk, Stephen Hoekstra
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ Enhancements
 Bug Fixes
 ---------
 * #572 - Issues with disabling SSL verification in Nessus
+* #571 - @SHoekstra fixed: testssl scan fails on docker because hexdump is not installed


### PR DESCRIPTION
Provides the `hexadump` bin which is needed by the `testssl.sh` scanner.