### PR TITLE
Graceful fail on Nessus export format internal error

### DIFF
--- a/scanners/Nessus6/scan
+++ b/scanners/Nessus6/scan
@@ -302,6 +302,13 @@ foreach my $format ( @formats ) {
         do {
             sleep(5);
             $json = rest_get("/scans/$sid/export/$filehandle/status", {}, \$r);
+            
+            #$json will be undefined if trying to export a fileformat will fail
+            if (!defined $json) {
+                print "Exporting scan to $format failed, skipping\n";
+                last;
+            }
+
             print Dumper $json;
             if ($r->code() eq 200) {
                 print "Scan export status: $json->{status}\n";
@@ -560,6 +567,10 @@ sub rest_call {
     # retry in this case
     unless ( $r->is_success || ( $uri =~ qr#/scans/\d+/export/\d+\/status# && $r->code() == 404 ) ) {
         unless ( $quiet ) {
+            #Internal server errors (500) should be fail gracefully so it does not loop
+            if ($uri =~ qr#/scans/\d+/export/\d+\/status# && $r->code() == 500) {
+                return;
+            }
             print "Nessus server returned error code: " . $r->code() . "\nMessage: " . $r->decoded_content();
             print "\n$retries retries left\n";
         }


### PR DESCRIPTION
This is a fix for https://github.com/schubergphilis/Seccubus/issues/603 in which an export might fail, in this case PDF because of nessus giving an internal 500 error, which would create a loop that does not decrease the retry counter because the variable $json becomes undefined.

Not the best fix (ideally the do/until should be fixed) but the best I could do.

Result when Nessus has no PDF export capabilities:
![image](https://user-images.githubusercontent.com/1157977/32966790-3b9c56aa-cbdb-11e7-88f7-e9dad80589cc.png)
