### PR TITLE
This will be version v2.50

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,28 @@ Seccubus V2 works with the following scanners:
 
 For more information visit [www.seccubus.com]
 
+5-11-2018 - v2.50 - Seccubus Alpine
+===================================
+This release brings new Alpine based docker containers and fixes a compatibility issue with MySQL/MariaDB version 8 and above.
+
+Differences with 2.48
+
+Enhancements
+------------
+* Seccubus containers are now built based on Alpine
+* Minimal specialized docker containers available for front end, api, front end+api, perl and cron
+
+Bug Fixes
+---------
+* Seccubus rpm's are now also being built for Fedora version 27 and 28
+* RPMs for Fedora version 25 depricated
+* Fixed building of supporting Centos v7 rpms
+* #585 - Added default credentials to the readme file
+* #660 - Sudo added to docker images
+* #655 - Shell set to /bin/bash for user seccubus
+# #662 - Fixing documentation typos
+* #673 - PERL5LIB set to /opt/seccubus for seccubus user via debian package
+
 9-5-2018 - v2.48 - Tenable.io compatibility and more
 ====================================================
 This release is fully compatible with the Tenable.io vulnerability management platform.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Changes of this branch vs the [latest/previous release](https://github.com/schub
 
 ---
 
-x-x-2018 - v2.49 - Developement release
-====================================================
-New docker containers and compatibility with MySQL/MariaDB version 8
+5-11-2018 - v2.50 - Seccubus Alpine
+===================================
+This release brings new Alpine based docker containers and fixes a compatibility issue with MySQL/MariaDB version 8 and above.
 
 Differences with 2.48
 

--- a/SeccubusV2.pm
+++ b/SeccubusV2.pm
@@ -57,7 +57,7 @@ use lib "/opt/seccubus/lib";
 use lib "lib";
 push (@main::INC, @INC);
 
-our $VERSION = '2.48';
+our $VERSION = '2.50';
 our $DBVERSION = 11;
 our $USER = '';
 


### PR DESCRIPTION
5-11-2018 - v2.50 - Seccubus Alpine
===================================
This release brings new Alpine based docker containers and fixes a compatibility issue with MySQL/MariaDB version 8 and above.

Differences with 2.48

Enhancements
------------
* Seccubus containers are now built based on Alpine
* Minimal specialized docker containers available for front end, api, front end+api, perl and cron

Bug Fixes
---------
* Seccubus rpm's are now also being built for Fedora version 27 and 28
* RPMs for Fedora version 25 depricated
* Fixed building of supporting Centos v7 rpms
* #585 - Added default credentials to the readme file
* #660 - Sudo added to docker images
* #655 - Shell set to /bin/bash for user seccubus
* #662 - Fixing documentation typos
* #673 - PERL5LIB set to /opt/seccubus for seccubus user via debian package
